### PR TITLE
:sparkles: (#7) [zsh] Add shell completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ commits](https://gist.github.com/qoomon/5dfcdf8eec66a051ecd85625518cfd13) DSL.
 ### Captain git-hook manager control file
 
 # params: NONE
-# Standard hook with triggers for linting, formatting, and running tests
+# Common hook with several triggers for linting, formatting, and running tests
 pre_commit=(
     'lint:             clj-kondo $CAPT_CHANGES &' # linting of files being committed
     'format(clj|cljc): cljfmt &'                  # reformat or check for poor formatting
@@ -305,20 +305,30 @@ prepare_commit_msg=(
     branch2message
 )
 # params: tmp-message-file-path
+# Validate your project state or commit message before allowing a commit to go through
 commit_msg=(
     'commitlint: msglint $GITARG1'  # ensure log message meets standards
 )
 # params: NONE
 # Examples: moving in large binary files that you don’t want source
 # controlled, auto-generating documentation, etc
+# General informative notices, no parameters
 post_commit=(
     "stimulate: play-post-commit-sound.sh"           # happy music on successful commit
     "colorize:  commit-colors $(git rev-parse HEAD)" # more confirmation rewards
 )
+# params: command that triggered rewrite, plus stdin for list of rewrites
+# Run by commands that replace commits, (amend/rebase); same uses as post-checkout, post-merge
+post_rewrite=(
+)
+
 # params: NONE
-# General informative notices, no parameters
+# Set up your working directory properly for your project environment
 post_checkout=(
     "mig-alert(sql): alert-migrations-pending.zsh" # inform that action is needed
+)
+# Use to validate a set of ref updates before a push occurs
+pre_push=(
 )
 # Not a git hook!
 clean_up=(

--- a/_capt
+++ b/_capt
@@ -1,0 +1,15 @@
+#compdef capt
+
+local -a subcmds=(
+'pre-commit:(hook) Common hook with several triggers for linting, formatting, and running tests'
+'prepare-commit_msg:(hook) Build a commit message based on branch name standardized format'
+'commit-msg:(hook) Validate your project state or commit message before allowing a commit to go through'
+'post-commit:(hook) For notifications'
+'post-rewrite:(hook) Run by commands that replace commits, (amend/rebase); same uses as post-checkout, post-merge'
+'post-checkout:(hook) Set up your working directory properly for your project environment'
+'pre-push:(hook) Use to validate a set of ref updates before a push occurs'
+'list:(cmd) List all active hooks'
+'edit:(cmd) See all active triggers and open EDITOR on their control files'
+'init:(cmd) Initialize Captain files into a project (ok to run multiple times)'
+)
+_describe 'command' subcmds

--- a/capt
+++ b/capt
@@ -74,8 +74,8 @@ if [[ $@[1] == 'help' ]]; then
     for b in ${(k)builtin_helps}; do printf '  %-16s%s\n' $b ${builtin_helps[$b]} ; done
     print '\nCommands:'
     print "  ${bold_color}list$reset_color   list of all active hooks"
-    print "  ${bold_color}edit$reset_color   see all active triggers"
-    print "  ${bold_color}setup$reset_color  initialize captain files newly into project"
+    print "  ${bold_color}edit$reset_color   see all active triggers in EDITOR"
+    print "  ${bold_color}setup$reset_color  initialize captain files into project (idempotent)"
     exit
 fi
 


### PR DESCRIPTION
Took the KISS approach and only created a simple hard-coded, redundant list of descriptions of all supported hooks (not the ones that are dynamically discovered).
